### PR TITLE
Disable webp if browser does not accept webp images

### DIFF
--- a/src/WebpGenerator.php
+++ b/src/WebpGenerator.php
@@ -23,7 +23,7 @@ final class WebpGenerator
             return $url;
         }
 
-        if (strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') !== true ) {
+        if (!empty($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') !== true ) {
             return $url;
         }
 

--- a/src/WebpGenerator.php
+++ b/src/WebpGenerator.php
@@ -23,7 +23,7 @@ final class WebpGenerator
             return $url;
         }
 
-        if (strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false) {
+        if (!empty($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false) {
             return $url;
         }
 

--- a/src/WebpGenerator.php
+++ b/src/WebpGenerator.php
@@ -23,7 +23,7 @@ final class WebpGenerator
             return $url;
         }
 
-        if (strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') !== true ) {
+        if (strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false) {
             return $url;
         }
 

--- a/src/WebpGenerator.php
+++ b/src/WebpGenerator.php
@@ -23,6 +23,10 @@ final class WebpGenerator
             return $url;
         }
 
+        if (strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') !== true ) {
+            return $url;
+        }
+
         $originalFilename = PUBLIC_PATH . $url;
         $url = $url . '.webp';
         $filename = PUBLIC_PATH . $url;


### PR DESCRIPTION
This feature will check if the browser accepts webp.

If the browser does not accept webp, we will just return the original image.