### PR TITLE
feature/chainable-template-methods

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -14,3 +14,7 @@ SilverStripe\Assets\Storage\DBFile:
 SilverStripe\Assets\File:
   allowed_extensions:
     - webp
+
+Silverstripe\Assets\Image:
+  extensions:
+    - WeDevelop\WebpImages\Asset\ImageExtension

--- a/src/Asset/ImageExtension.php
+++ b/src/Asset/ImageExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WeDevelop\WebpImages\Asset;
+
+use SilverStripe\Core\Extension;
+use WeDevelop\WebpImages\WebpGenerator;
+
+class ImageExtension extends Extension
+{
+    public function EnableWebP()
+    {
+        WebpGenerator::singleton()->setEnabledForNextGenerate(true);
+
+        return $this->getOwner();
+    }
+
+    public function DisableWebP()
+    {
+        WebpGenerator::singleton()->setEnabledForNextGenerate(false);
+
+        return $this->getOwner();
+    }
+}

--- a/src/Storage/DBFileExtension.php
+++ b/src/Storage/DBFileExtension.php
@@ -16,10 +16,10 @@ class DBFileExtension extends Extension
 {
     public function updateURL(&$url): void
     {
-        if (!$this->owner->getIsImage() || $this->owner->getVisibility() !== AssetStore::VISIBILITY_PUBLIC) {
+        if (!$this->getOwner()->getIsImage() || $this->getOwner()->getVisibility() !== AssetStore::VISIBILITY_PUBLIC) {
             return;
         }
 
-        $url = WebpGenerator::singleton()->generate($url, $this->owner->getMimeType());
+        $url = WebpGenerator::singleton()->generate($url, $this->getOwner()->getMimeType());
     }
 }

--- a/src/WebpGenerator.php
+++ b/src/WebpGenerator.php
@@ -10,6 +10,7 @@ final class WebpGenerator
 {
     use Injectable;
 
+    private ?bool $enabledForNextGenerate = null;
     public bool $enabled = true;
     public int $quality = 80;
 
@@ -61,6 +62,24 @@ final class WebpGenerator
 
     public function getEnabled(): bool
     {
+        if (is_bool($this->getEnabledForNextGenerate())) {
+            $state = $this->getEnabledForNextGenerate();
+
+            $this->enabledForNextGenerate = null;
+
+            return $state;
+        }
+
         return $this->enabled;
+    }
+
+    public function setEnabledForNextGenerate(bool $enabled): void
+    {
+        $this->enabledForNextGenerate = $enabled;
+    }
+
+    public function getEnabledForNextGenerate(): ?bool
+    {
+        return $this->enabledForNextGenerate;
     }
 }


### PR DESCRIPTION
- Adds an ImageExtension
- Switches instances of ->owner to ->getOwner()
- Adds enabledForNextGenerate that can override the enabled state for 1 image generate call
- Adds chainable DisableWebP and EnableWebP to Image instances to allow the following in templates

`$Image.DisableWebP.AbsoluteURL`